### PR TITLE
JNG-3902 Fix timestamp asstring

### DIFF
--- a/adapter-asm-test/src/test/java/hu/blackbelt/judo/meta/expression/ExecutionContextOnAsmTest.java
+++ b/adapter-asm-test/src/test/java/hu/blackbelt/judo/meta/expression/ExecutionContextOnAsmTest.java
@@ -99,7 +99,7 @@ public class ExecutionContextOnAsmTest {
     			newEEnumLiteralBuilder().withLiteral("DR").withName("DR").withValue(3).build()).build();
     	
     	//types
-    	EDataType timestamp = newEDataTypeBuilder().withName("Timestamp").withInstanceClassName("java.time.OffsetDateTime").build();
+    	EDataType timestamp = newEDataTypeBuilder().withName("Timestamp").withInstanceClassName("java.time.LocalDateTime").build();
     	EDataType stringType = newEDataTypeBuilder().withName("String").withInstanceClassName("java.lang.String").build();
     	EDataType doubleType = newEDataTypeBuilder().withName("Double").withInstanceClassName("java.lang.Double").build();
     	EDataType integerType = newEDataTypeBuilder().withName("Integer").withInstanceClassName("java.lang.Integer").build();

--- a/adapter-asm-test/src/test/java/hu/blackbelt/judo/meta/expression/runtime/ExpressionModelForTest.java
+++ b/adapter-asm-test/src/test/java/hu/blackbelt/judo/meta/expression/runtime/ExpressionModelForTest.java
@@ -40,6 +40,7 @@ import java.time.OffsetDateTime;
 import org.eclipse.emf.common.util.URI;
 
 import java.math.BigDecimal;
+import java.time.ZoneOffset;
 
 import hu.blackbelt.judo.meta.expression.StringExpression;
 import hu.blackbelt.judo.meta.expression.TypeName;
@@ -319,7 +320,7 @@ public class ExpressionModelForTest {
         		.build();
         
         TimestampAdditionExpression tsAddExpr1 = newTimestampAdditionExpressionBuilder()
-        		.withTimestamp(newTimestampConstantBuilder().withValue(OffsetDateTime.parse("2019-01-02T03:04:05.678+01:00")).build())
+        		.withTimestamp(newTimestampConstantBuilder().withValue(OffsetDateTime.parse("2019-01-02T03:04:05.678+01:00").atZoneSameInstant(ZoneOffset.UTC).toLocalDateTime()).build())
         		.withDuration(newMeasuredDecimalBuilder().withValue(BigDecimal.valueOf(102)).withUnitName("s").build())
         		.build();
         
@@ -335,8 +336,8 @@ public class ExpressionModelForTest {
         		.build();
         
         TimestampDifferenceExpression tsDiffExpr = newTimestampDifferenceExpressionBuilder()
-        		.withStartTimestamp(newTimestampConstantBuilder().withValue(OffsetDateTime.parse("2019-01-02T03:04:05.678+01:00")).build())
-        		.withEndTimestamp(newTimestampConstantBuilder().withValue(OffsetDateTime.parse("2019-01-30T15:57:08.123+01:00")).build())
+        		.withStartTimestamp(newTimestampConstantBuilder().withValue(OffsetDateTime.parse("2019-01-02T03:04:05.678+01:00").atZoneSameInstant(ZoneOffset.UTC).toLocalDateTime()).build())
+        		.withEndTimestamp(newTimestampConstantBuilder().withValue(OffsetDateTime.parse("2019-01-30T15:57:08.123+01:00").atZoneSameInstant(ZoneOffset.UTC).toLocalDateTime()).build())
         		.build();
         
         ContainerExpression contExpr = newContainerExpressionBuilder().withElementName(order)

--- a/builder-jql-asm-test/src/test/java/hu/blackbelt/judo/meta/expression/builder/jql/asm/AsmJqlExpressionBuilderTest.java
+++ b/builder-jql-asm-test/src/test/java/hu/blackbelt/judo/meta/expression/builder/jql/asm/AsmJqlExpressionBuilderTest.java
@@ -824,8 +824,8 @@ public class AsmJqlExpressionBuilderTest extends ExecutionContextOnAsmTest {
         createExpression("9[mm]/(1/45[cm])");
         createExpression("9[mg] < 2[kg]");
         createExpression("`2019-01-02T03:04:05.678+01:00` + 102[s]");
-        Expression timeStampAddition = createExpression("demo::entities::Order!sort()!head().orderDate - 3[day]");
-        assertThat(timeStampAddition, instanceOf(TimestampExpression.class));
+        Expression timestampAddition = createExpression("demo::entities::Order!sort()!head().orderDate - 3[day]");
+        assertThat(timestampAddition, instanceOf(TimestampExpression.class));
         createExpression("`2019-01-02T03:04:05.678+01:00`!elapsedTimeFrom(`2019-01-30T15:57:08.123+01:00`)");
 
         Expression customerExpression = createExpression(

--- a/builder-jql-asm-test/src/test/java/hu/blackbelt/judo/meta/expression/builder/jql/asm/AsmJqlExpressionBuilderTest.java
+++ b/builder-jql-asm-test/src/test/java/hu/blackbelt/judo/meta/expression/builder/jql/asm/AsmJqlExpressionBuilderTest.java
@@ -26,8 +26,7 @@ import hu.blackbelt.judo.meta.asm.runtime.AsmUtils;
 import hu.blackbelt.judo.meta.expression.*;
 import hu.blackbelt.judo.meta.expression.builder.jql.*;
 import hu.blackbelt.judo.meta.expression.collection.*;
-import hu.blackbelt.judo.meta.expression.constant.DateConstant;
-import hu.blackbelt.judo.meta.expression.constant.MeasuredDecimal;
+import hu.blackbelt.judo.meta.expression.constant.*;
 import hu.blackbelt.judo.meta.expression.numeric.DecimalSwitchExpression;
 import hu.blackbelt.judo.meta.expression.object.*;
 import hu.blackbelt.judo.meta.expression.runtime.ExpressionEpsilonValidator;
@@ -45,6 +44,7 @@ import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.time.*;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.stream.Stream;
@@ -1191,6 +1191,140 @@ public class AsmJqlExpressionBuilderTest extends ExecutionContextOnAsmTest {
         JqlExpressionBuildException exception =
                 assertThrows(JqlExpressionBuildException.class, () -> createExpression("schools::Person.height"));
         assertThat(exception.getMessage(), containsString(INVALID_ATTRIBUTE_SELECTOR));
+    }
+
+    @Test
+    public void testTimeCreation() {
+        Expression expression = assertDoesNotThrow(() -> createExpression("`11:11`"));
+        assertTrue(expression instanceof TimeConstant);
+        assertEquals(LocalTime.parse("11:11"), ((TimeConstant) expression).getValue());
+
+        Expression expression1 = assertDoesNotThrow(() -> createExpression("`11:11:11`"));
+        assertTrue(expression1 instanceof TimeConstant);
+        assertEquals(LocalTime.parse("11:11:11"), ((TimeConstant) expression1).getValue());
+
+        Expression expression2 = assertDoesNotThrow(() -> createExpression("`11:11:11.111`"));
+        assertTrue(expression2 instanceof TimeConstant);
+        assertEquals(LocalTime.parse("11:11:11.111"), ((TimeConstant) expression2).getValue());
+
+        Expression expression3 = assertDoesNotThrow(() -> createExpression("demo::types::Time!of(11, 11)"));
+        Expression expression4 = assertDoesNotThrow(() -> createExpression("demo::types::Time!of(11, 11, 11)"));
+        Expression expression5 = assertDoesNotThrow(() -> createExpression("demo::types::Time!of(11, 11, 11, 111)"));
+
+        assertThrows(JqlExpressionBuildException.class, () -> createExpression("demo::types::Time!of()"));
+        assertThrows(JqlExpressionBuildException.class, () -> createExpression("demo::types::Time!of(11)"));
+        assertThrows(JqlExpressionBuildException.class, () -> createExpression("demo::types::Time!of(11, 11, 11, 11, 11)"));
+    }
+
+    @Test
+    public void testTimestampCreation() {
+        Expression timestampConstant1 = assertDoesNotThrow(() -> createExpression("`2023-03-17T11:11`"));
+        assertTrue(timestampConstant1 instanceof TimestampConstant);
+        assertEquals(((TimestampConstant) timestampConstant1).getValue(), LocalDateTime.parse("2023-03-17T11:11"));
+
+        Expression timestampConstant2 = assertDoesNotThrow(() -> createExpression("`2023-03-17T11:11Z`"));
+        assertTrue(timestampConstant2 instanceof TimestampConstant);
+        assertEquals(((TimestampConstant) timestampConstant2).getValue(), OffsetDateTime.parse("2023-03-17T11:11Z").atZoneSameInstant(ZoneOffset.UTC).toLocalDateTime());
+
+        Expression timestampConstant3 = assertDoesNotThrow(() -> createExpression("`2023-03-17T11:11+01`"));
+        assertTrue(timestampConstant3 instanceof TimestampConstant);
+        assertEquals(((TimestampConstant) timestampConstant3).getValue(), OffsetDateTime.parse("2023-03-17T11:11+01").atZoneSameInstant(ZoneOffset.UTC).toLocalDateTime());
+
+        Expression timestampConstant4 = assertDoesNotThrow(() -> createExpression("`2023-03-17T11:11-01`"));
+        assertTrue(timestampConstant4 instanceof TimestampConstant);
+        assertEquals(((TimestampConstant) timestampConstant4).getValue(), OffsetDateTime.parse("2023-03-17T11:11-01").atZoneSameInstant(ZoneOffset.UTC).toLocalDateTime());
+
+        Expression timestampConstant5 = assertDoesNotThrow(() -> createExpression("`2023-03-17T11:11+01:01`"));
+        assertTrue(timestampConstant5 instanceof TimestampConstant);
+        assertEquals(((TimestampConstant) timestampConstant5).getValue(), OffsetDateTime.parse("2023-03-17T11:11+01:01").atZoneSameInstant(ZoneOffset.UTC).toLocalDateTime());
+
+        Expression timestampConstant6 = assertDoesNotThrow(() -> createExpression("`2023-03-17T11:11-01:01`"));
+        assertTrue(timestampConstant6 instanceof TimestampConstant);
+        assertEquals(((TimestampConstant) timestampConstant6).getValue(), OffsetDateTime.parse("2023-03-17T11:11-01:01").atZoneSameInstant(ZoneOffset.UTC).toLocalDateTime());
+
+        Expression timestampConstant7 = assertDoesNotThrow(() -> createExpression("`2023-03-17T11:11:11`"));
+        assertTrue(timestampConstant7 instanceof TimestampConstant);
+        assertEquals(((TimestampConstant) timestampConstant7).getValue(), LocalDateTime.parse("2023-03-17T11:11:11"));
+
+        Expression timestampConstant8 = assertDoesNotThrow(() -> createExpression("`2023-03-17T11:11:11Z`"));
+        assertTrue(timestampConstant8 instanceof TimestampConstant);
+        assertEquals(((TimestampConstant) timestampConstant8).getValue(), OffsetDateTime.parse("2023-03-17T11:11:11Z").atZoneSameInstant(ZoneOffset.UTC).toLocalDateTime());
+
+        Expression timestampConstant9 = assertDoesNotThrow(() -> createExpression("`2023-03-17T11:11:11+01`"));
+        assertTrue(timestampConstant9 instanceof TimestampConstant);
+        assertEquals(((TimestampConstant) timestampConstant9).getValue(), OffsetDateTime.parse("2023-03-17T11:11:11+01").atZoneSameInstant(ZoneOffset.UTC).toLocalDateTime());
+
+        Expression timestampConstant10 = assertDoesNotThrow(() -> createExpression("`2023-03-17T11:11:11-01`"));
+        assertTrue(timestampConstant10 instanceof TimestampConstant);
+        assertEquals(((TimestampConstant) timestampConstant10).getValue(), OffsetDateTime.parse("2023-03-17T11:11:11-01").atZoneSameInstant(ZoneOffset.UTC).toLocalDateTime());
+
+        Expression timestampConstant11 = assertDoesNotThrow(() -> createExpression("`2023-03-17T11:11:11+01:01`"));
+        assertTrue(timestampConstant11 instanceof TimestampConstant);
+        assertEquals(((TimestampConstant) timestampConstant11).getValue(), OffsetDateTime.parse("2023-03-17T11:11:11+01:01").atZoneSameInstant(ZoneOffset.UTC).toLocalDateTime());
+
+        Expression timestampConstant12 = assertDoesNotThrow(() -> createExpression("`2023-03-17T11:11:11-01:01`"));
+        assertTrue(timestampConstant12 instanceof TimestampConstant);
+        assertEquals(((TimestampConstant) timestampConstant12).getValue(), OffsetDateTime.parse("2023-03-17T11:11:11-01:01").atZoneSameInstant(ZoneOffset.UTC).toLocalDateTime());
+
+        Expression timestampConstant13 = assertDoesNotThrow(() -> createExpression("`2023-03-17T11:11:11.111`"));
+        assertTrue(timestampConstant13 instanceof TimestampConstant);
+        assertEquals(((TimestampConstant) timestampConstant13).getValue(), LocalDateTime.parse("2023-03-17T11:11:11.111"));
+
+        Expression timestampConstant14 = assertDoesNotThrow(() -> createExpression("`2023-03-17T11:11:11.111Z`"));
+        assertTrue(timestampConstant14 instanceof TimestampConstant);
+        assertEquals(((TimestampConstant) timestampConstant14).getValue(), OffsetDateTime.parse("2023-03-17T11:11:11.111Z").atZoneSameInstant(ZoneOffset.UTC).toLocalDateTime());
+
+        Expression timestampConstant15 = assertDoesNotThrow(() -> createExpression("`2023-03-17T11:11:11.111+01`"));
+        assertTrue(timestampConstant15 instanceof TimestampConstant);
+        assertEquals(((TimestampConstant) timestampConstant15).getValue(), OffsetDateTime.parse("2023-03-17T11:11:11.111+01").atZoneSameInstant(ZoneOffset.UTC).toLocalDateTime());
+
+        Expression timestampConstant16 = assertDoesNotThrow(() -> createExpression("`2023-03-17T11:11:11.111-01`"));
+        assertTrue(timestampConstant16 instanceof TimestampConstant);
+        assertEquals(((TimestampConstant) timestampConstant16).getValue(), OffsetDateTime.parse("2023-03-17T11:11:11.111-01").atZoneSameInstant(ZoneOffset.UTC).toLocalDateTime());
+
+        Expression timestampConstant17 = assertDoesNotThrow(() -> createExpression("`2023-03-17T11:11:11.111+01:01`"));
+        assertTrue(timestampConstant17 instanceof TimestampConstant);
+        assertEquals(((TimestampConstant) timestampConstant17).getValue(), OffsetDateTime.parse("2023-03-17T11:11:11.111+01:01").atZoneSameInstant(ZoneOffset.UTC).toLocalDateTime());
+
+        Expression timestampConstant18 = assertDoesNotThrow(() -> createExpression("`2023-03-17T11:11:11.111-01:01`"));
+        assertTrue(timestampConstant18 instanceof TimestampConstant);
+        assertEquals(((TimestampConstant) timestampConstant18).getValue(), OffsetDateTime.parse("2023-03-17T11:11:11.111-01:01").atZoneSameInstant(ZoneOffset.UTC).toLocalDateTime());
+
+        Expression timestampFromDate = assertDoesNotThrow(() -> createExpression("demo::types::Timestamp!of(`2022-09-19`)"));
+        Expression timestampFromDateAndTime = assertDoesNotThrow(() -> createExpression("demo::types::Timestamp!of(`2022-09-19`, `11:11`)"));
+        Expression timestampFromDateAndTime1 = assertDoesNotThrow(() -> createExpression("demo::types::Timestamp!of(`2022-09-19`, `11:11:11`)"));
+        Expression timestampFromDateAndTime2 = assertDoesNotThrow(() -> createExpression("demo::types::Timestamp!of(`2022-09-19`, `11:11:11.111`)"));
+        Expression timestampFromDateAndTimeConstruction = assertDoesNotThrow(() -> createExpression("demo::types::Timestamp!of(demo::types::Date!of(2022, 09, 19), demo::types::Time!of(11, 11))"));
+        Expression timestampFromDateAndTimeConstruction1 = assertDoesNotThrow(() -> createExpression("demo::types::Timestamp!of(demo::types::Date!of(2022, 09, 19), demo::types::Time!of(11, 11, 11))"));
+        Expression timestampFromDateAndTimeConstruction2 = assertDoesNotThrow(() -> createExpression("demo::types::Timestamp!of(demo::types::Date!of(2022, 09, 19), demo::types::Time!of(11, 11, 11, 11))"));
+        Expression timestampFromIntegers = assertDoesNotThrow(() -> createExpression("demo::types::Timestamp!of(2022, 9, 19, 11, 11)"));
+        Expression timestampFromIntegers1 = assertDoesNotThrow(() -> createExpression("demo::types::Timestamp!of(2022, 9, 19, 11, 11, 11)"));
+        Expression timestampFromIntegers2 = assertDoesNotThrow(() -> createExpression("demo::types::Timestamp!of(2022, 9, 19, 11, 11, 11, 11)"));
+
+        assertThrows(JqlExpressionBuildException.class, () -> createExpression("demo::types::Timestamp!of(`11:11:11`)"));
+        assertThrows(JqlExpressionBuildException.class, () -> createExpression("demo::types::Timestamp!of(`11:11:11`, `2022-09-19`)"));
+        assertThrows(JqlExpressionBuildException.class, () -> createExpression("demo::types::Timestamp!of(2022, 9, 19, 11)"));
+        assertThrows(JqlExpressionBuildException.class, () -> createExpression("demo::types::Timestamp!of(2022, 9, 19, 11, 11, 11, 11, 11)"));
+    }
+
+    @Test
+    public void testTimestampConversion() {
+        Expression timestampAsMilliseconds = createExpression("demo::types::Timestamp!of(`2022-09-19`)!asMilliseconds()");
+        Expression timestampFromMilliseconds = createExpression("demo::types::Timestamp!fromMilliseconds(9999999999)");
+
+        assertThrows(JqlExpressionBuildException.class, () -> createExpression("demo::types::Timestamp!fromMilliseconds()"));
+        assertThrows(JqlExpressionBuildException.class, () -> createExpression("demo::types::Timestamp!fromMilliseconds(9999999999, 999999)"));
+        assertThrows(JqlExpressionBuildException.class, () -> createExpression("demo::types::Date!fromMilliseconds(9999999999)"));
+    }
+
+    @Test
+    public void testTimeConversion() {
+        Expression timeAsMilliseconds = createExpression("demo::types::Time!of(11, 11, 11)!asMilliseconds()");
+        Expression timeFromMilliseconds = createExpression("demo::types::Time!fromMilliseconds(99999999)");
+
+        assertThrows(JqlExpressionBuildException.class, () -> createExpression("demo::types::Time!fromMilliseconds()"));
+        assertThrows(JqlExpressionBuildException.class, () -> createExpression("demo::types::Time!fromMilliseconds(9999999999, 999999)"));
+        assertThrows(JqlExpressionBuildException.class, () -> createExpression("demo::types::Date!fromMilliseconds(9999999999)"));
     }
 
 }

--- a/builder-jql-asm-test/src/test/java/hu/blackbelt/judo/meta/expression/builder/jql/asm/ExecutionContextOnAsmTest.java
+++ b/builder-jql-asm-test/src/test/java/hu/blackbelt/judo/meta/expression/builder/jql/asm/ExecutionContextOnAsmTest.java
@@ -83,7 +83,7 @@ public class ExecutionContextOnAsmTest {
                 newEEnumLiteralBuilder().withLiteral("SK").withName("SK").withValue(3).build()).build();
         
         //types
-        EDataType timestamp = newEDataTypeBuilder().withName("Timestamp").withInstanceClassName("java.time.OffsetDateTime").build();
+        EDataType timestamp = newEDataTypeBuilder().withName("Timestamp").withInstanceClassName("java.time.LocalDateTime").build();
         EDataType time = newEDataTypeBuilder().withName("Time").withInstanceClassName("java.time.LocalTime").build();
         EDataType stringType = newEDataTypeBuilder().withName("String").withInstanceClassName("java.lang.String").build();
         doubleType = newEDataTypeBuilder().withName("Double").withInstanceClassName("java.lang.Double").build();

--- a/pom.xml
+++ b/pom.xml
@@ -91,9 +91,9 @@
         <cxf-version>3.4.4</cxf-version>
         <pax-exam-version>4.13.4</pax-exam-version>
 
-		<judo-meta-expression-version>1.0.5.20230316_170744_7312c2f4_feature_JNG_3902_Fix_timestamp_asstring</judo-meta-expression-version>
+		<judo-meta-expression-version>1.0.5.20230320_201007_7cd92891_feature_JNG_3902_Fix_timestamp_asstring</judo-meta-expression-version>
         <judo-meta-asm-version>1.1.4.20230310_041340_c5dd0888_develop</judo-meta-asm-version>
-        <judo-meta-jql-version>1.0.4.20230316_165956_45f92d19_feature_JNG_3902_Fix_timestamp_asstring</judo-meta-jql-version>
+        <judo-meta-jql-version>1.0.4.20230320_191020_66a9724e_feature_JNG_3902_Fix_timestamp_asstring</judo-meta-jql-version>
         <judo-meta-measure-version>1.0.2.20230310_041354_f9e5d334_develop</judo-meta-measure-version>
 
         <!-- Define overridable properties for tycho-surefire-plugin -->

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <cxf-version>3.4.4</cxf-version>
         <pax-exam-version>4.13.4</pax-exam-version>
 
-		<judo-meta-expression-version>1.0.5.20230310_041813_3b870a60_develop</judo-meta-expression-version>
+		<judo-meta-expression-version>1.0.5.20230310_112542_8f5bdaba_feature_JNG_3902_Fix_timestamp_asstring</judo-meta-expression-version>
         <judo-meta-asm-version>1.1.4.20230310_041340_c5dd0888_develop</judo-meta-asm-version>
         <judo-meta-jql-version>1.0.4.20230310_040742_ca88306a_develop</judo-meta-jql-version>
         <judo-meta-measure-version>1.0.2.20230310_041354_f9e5d334_develop</judo-meta-measure-version>

--- a/pom.xml
+++ b/pom.xml
@@ -91,9 +91,9 @@
         <cxf-version>3.4.4</cxf-version>
         <pax-exam-version>4.13.4</pax-exam-version>
 
-		<judo-meta-expression-version>1.0.5.20230320_201007_7cd92891_feature_JNG_3902_Fix_timestamp_asstring</judo-meta-expression-version>
+		<judo-meta-expression-version>1.0.5.20230321_173750_b9b97228_feature_JNG_3902_Fix_timestamp_asstring</judo-meta-expression-version>
         <judo-meta-asm-version>1.1.4.20230310_041340_c5dd0888_develop</judo-meta-asm-version>
-        <judo-meta-jql-version>1.0.4.20230320_191020_66a9724e_feature_JNG_3902_Fix_timestamp_asstring</judo-meta-jql-version>
+        <judo-meta-jql-version>1.0.4.20230321_173048_df8bbdc1_feature_JNG_3902_Fix_timestamp_asstring</judo-meta-jql-version>
         <judo-meta-measure-version>1.0.2.20230310_041354_f9e5d334_develop</judo-meta-measure-version>
 
         <!-- Define overridable properties for tycho-surefire-plugin -->

--- a/pom.xml
+++ b/pom.xml
@@ -91,9 +91,9 @@
         <cxf-version>3.4.4</cxf-version>
         <pax-exam-version>4.13.4</pax-exam-version>
 
-		<judo-meta-expression-version>1.0.5.20230315_225621_d95d439b_feature_JNG_3902_Fix_timestamp_asstring</judo-meta-expression-version>
+		<judo-meta-expression-version>1.0.5.20230316_170744_7312c2f4_feature_JNG_3902_Fix_timestamp_asstring</judo-meta-expression-version>
         <judo-meta-asm-version>1.1.4.20230310_041340_c5dd0888_develop</judo-meta-asm-version>
-        <judo-meta-jql-version>1.0.4.20230315_225121_57e19b10_feature_JNG_3902_Fix_timestamp_asstring</judo-meta-jql-version>
+        <judo-meta-jql-version>1.0.4.20230316_165956_45f92d19_feature_JNG_3902_Fix_timestamp_asstring</judo-meta-jql-version>
         <judo-meta-measure-version>1.0.2.20230310_041354_f9e5d334_develop</judo-meta-measure-version>
 
         <!-- Define overridable properties for tycho-surefire-plugin -->

--- a/pom.xml
+++ b/pom.xml
@@ -91,9 +91,9 @@
         <cxf-version>3.4.4</cxf-version>
         <pax-exam-version>4.13.4</pax-exam-version>
 
-		<judo-meta-expression-version>1.0.5.20230310_112542_8f5bdaba_feature_JNG_3902_Fix_timestamp_asstring</judo-meta-expression-version>
+		<judo-meta-expression-version>1.0.5.20230315_225621_d95d439b_feature_JNG_3902_Fix_timestamp_asstring</judo-meta-expression-version>
         <judo-meta-asm-version>1.1.4.20230310_041340_c5dd0888_develop</judo-meta-asm-version>
-        <judo-meta-jql-version>1.0.4.20230310_040742_ca88306a_develop</judo-meta-jql-version>
+        <judo-meta-jql-version>1.0.4.20230315_225121_57e19b10_feature_JNG_3902_Fix_timestamp_asstring</judo-meta-jql-version>
         <judo-meta-measure-version>1.0.2.20230310_041354_f9e5d334_develop</judo-meta-measure-version>
 
         <!-- Define overridable properties for tycho-surefire-plugin -->

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <timestamp>${maven.build.timestamp}</timestamp>
         <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
 
-		<epsilon-runtime-version>1.5.1.20230206_213546_3ade0dbb_develop</epsilon-runtime-version>
+		<epsilon-runtime-version>1.5.1.20230309_124841_a606c49f_develop</epsilon-runtime-version>
 		<epsilon-runtime-eclipse-version>1.5.4.20230228_151544_2976a285_develop</epsilon-runtime-eclipse-version>
         
         <src.dir>src/main</src.dir>
@@ -91,10 +91,10 @@
         <cxf-version>3.4.4</cxf-version>
         <pax-exam-version>4.13.4</pax-exam-version>
 
-		<judo-meta-expression-version>1.0.5.20230308_220602_28d80377_feature_JNG_3902_Fix_timestamp_asstring</judo-meta-expression-version>
-        <judo-meta-asm-version>1.1.4.20230301_041300_52553682_develop</judo-meta-asm-version>
-        <judo-meta-jql-version>1.0.4.20230301_040932_81b5ba16_develop</judo-meta-jql-version>
-        <judo-meta-measure-version>1.0.2.20230301_041300_fd454131_develop</judo-meta-measure-version>
+		<judo-meta-expression-version>1.0.5.20230309_134713_4b0d6928_feature_JNG_3902_Fix_timestamp_asstring</judo-meta-expression-version>
+        <judo-meta-asm-version>1.1.4.20230309_101715_61a4b6a1_develop</judo-meta-asm-version>
+        <judo-meta-jql-version>1.0.4.20230309_102230_fc099c5d_develop</judo-meta-jql-version>
+        <judo-meta-measure-version>1.0.2.20230309_102454_5d1684ae_develop</judo-meta-measure-version>
 
         <!-- Define overridable properties for tycho-surefire-plugin -->
         <platformSystemProperties />

--- a/pom.xml
+++ b/pom.xml
@@ -91,9 +91,9 @@
         <cxf-version>3.4.4</cxf-version>
         <pax-exam-version>4.13.4</pax-exam-version>
 
-		<judo-meta-expression-version>1.0.5.20230322_040741_9a76dcb5_develop</judo-meta-expression-version>
+		<judo-meta-expression-version>1.0.5.20230322_125424_6f2255f6_feature_JNG_3902_Fix_timestamp_asstring</judo-meta-expression-version>
         <judo-meta-asm-version>1.1.4.20230310_041340_c5dd0888_develop</judo-meta-asm-version>
-        <judo-meta-jql-version>1.0.4.20230321_161806_dc84a08e_develop</judo-meta-jql-version>
+        <judo-meta-jql-version>1.0.4.20230321_173048_df8bbdc1_feature_JNG_3902_Fix_timestamp_asstring</judo-meta-jql-version>
         <judo-meta-measure-version>1.0.2.20230310_041354_f9e5d334_develop</judo-meta-measure-version>
 
         <!-- Define overridable properties for tycho-surefire-plugin -->

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <cxf-version>3.4.4</cxf-version>
         <pax-exam-version>4.13.4</pax-exam-version>
 
-		<judo-meta-expression-version>1.0.5.20230301_041516_0da32240_develop</judo-meta-expression-version>
+		<judo-meta-expression-version>1.0.5.20230308_220602_28d80377_feature_JNG_3902_Fix_timestamp_asstring</judo-meta-expression-version>
         <judo-meta-asm-version>1.1.4.20230301_041300_52553682_develop</judo-meta-asm-version>
         <judo-meta-jql-version>1.0.4.20230301_040932_81b5ba16_develop</judo-meta-jql-version>
         <judo-meta-measure-version>1.0.2.20230301_041300_fd454131_develop</judo-meta-measure-version>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-3902" title="JNG-3902" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-3902</a>  Timestamp.asString() produces wrong output
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

JNG-3902 Fix timestamp asstring